### PR TITLE
tsan: fix tsan data race

### DIFF
--- a/include/vcml/silkit/participant.h
+++ b/include/vcml/silkit/participant.h
@@ -33,6 +33,7 @@ public:
     property<string> registry_uri;
     property<string> name;
     property<string> cfg_path;
+    property<bool> coordinated;
 
     virtual SilKit::IParticipant* get_silkit_part() { return m_silkit_part; }
 

--- a/test/sanitizer/tsan.suppress
+++ b/test/sanitizer/tsan.suppress
@@ -18,6 +18,3 @@ race:sc_core::sc_prim_channel_registry::async_update_list::append
 # fibers are considered as individual threads, and we call suspend() from the
 # main thread, but sometimes also from vcml processor SC_THREADS
 mutex:vcml::thctl::suspend
-
-# deleting a participant before lifecycleservice gets deleted generates a data race
-race:SilKit::_detail_v1::Impl::Services::Orchestration::LifecycleService::~LifecycleService


### PR DESCRIPTION
In coordinate mode the test never leaves the init state because it waits for other participants to join and cannot be stopped.
In autonomous mode it does not wait and can be stopped by calling the stop function.
Adding property to switch between these two modes.